### PR TITLE
Add CVE-2021-3564

### DIFF
--- a/cvehound/cve/CVE-2021-3564.cocci
+++ b/cvehound/cve/CVE-2021-3564.cocci
@@ -1,27 +1,25 @@
 /// Files: net/bluetooth/hci_core.c
-/// Fixes: 6a137caec23aeb9e036cdfd8a46dd8a366460e5d
+/// Fix: 6a137caec23aeb9e036cdfd8a46dd8a366460e5d
+/// Detect-To: b78752cc71d86998d3b77d873c61d6ffdb7a2142
 
 virtual detect
 
 @err exists@
 identifier hdev;
-position p_rx_flush;
-position p_cmd_flush;
+position p;
 @@
 
-
-
-static int hci_dev_do_open(struct hci_dev *hdev)
+\(hci_dev_open\|hci_dev_do_open\)(...)
 {
-	...
-	flush_work@p_cmd_flush(&hdev->cmd_work);
-	flush_work@p_rx_flush(&hdev->rx_work);
-	...
+        ...
+*       \(flush_work@p\|tasklet_kill@p\)(&hdev->\(cmd_work\|cmd_task\));
+        \(flush_work\|tasklet_kill\)(&hdev->\(rx_work\|rx_task\));
+        ...
 }
 
 
 @script:python depends on detect@
-p << err.p_cmd_flush;
+p << err.p;
 @@
 
 coccilib.report.print_report(p[0], 'ERROR: CVE-2021-3564')

--- a/cvehound/cve/CVE-2021-3564.cocci
+++ b/cvehound/cve/CVE-2021-3564.cocci
@@ -1,0 +1,27 @@
+/// Files: net/bluetooth/hci_core.c
+/// Fixes: 6a137caec23aeb9e036cdfd8a46dd8a366460e5d
+
+virtual detect
+
+@err exists@
+identifier hdev;
+position p_rx_flush;
+position p_cmd_flush;
+@@
+
+
+
+static int hci_dev_do_open(struct hci_dev *hdev)
+{
+	...
+	flush_work@p_cmd_flush(&hdev->cmd_work);
+	flush_work@p_rx_flush(&hdev->rx_work);
+	...
+}
+
+
+@script:python depends on detect@
+p << err.p_cmd_flush;
+@@
+
+coccilib.report.print_report(p[0], 'ERROR: CVE-2021-3564')


### PR DESCRIPTION
Попробовал добавить свой детект для уязвимости. Протестировал на версиях 3.12.9 (еще не появилась), 3.13 (уязвима), 4.14.194(уязвима), 4.14.236 (исправлена)