### PR TITLE
Add CVE-2021-43267

### DIFF
--- a/cvehound/cve/CVE-2021-43267.cocci
+++ b/cvehound/cve/CVE-2021-43267.cocci
@@ -1,0 +1,29 @@
+/// Files: net/tipc/crypto.c
+/// Fix: fa40d9734a57bcbfa79a280189799f76c88f7bb0
+/// Fixes: 1ef6f7c9390ff5308c940ff8d0a53533a4673ad9
+
+virtual detect
+
+@err_tipc_crypto_key_rcv exists@
+identifier skey, size, keylen;
+statement S1, S2;
+symbol TIPC_AEAD_KEYLEN_MIN, TIPC_AEAD_KEY_SIZE_MAX;
+position p;
+@@
+
+tipc_crypto_key_rcv(...)
+{
+	... when != if (unlikely(size < sizeof(struct tipc_aead_key) + TIPC_AEAD_KEYLEN_MIN)) S1
+
+	    when != if (unlikely(size != keylen + sizeof(struct tipc_aead_key) || keylen > TIPC_AEAD_KEY_SIZE_MAX)) S2
+ 
+	memcpy@p(skey->key, ...,
+	         skey->keylen);
+	...
+}
+
+@script:python depends on detect@
+p << err_tipc_crypto_key_rcv.p;
+@@
+
+coccilib.report.print_report(p[0], 'ERROR: CVE-2021-43267')


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-43267

```
$ cvehound --kernel ~/linux --config --cve CVE-2021-43267
Found: CVE-2021-43267
https://www.linuxkernelcves.com/cves/CVE-2021-43267
Affected Files:
 - net/tipc/crypto.c: CONFIG_TIPC & CONFIG_TIPC_CRYPTO
   /home/spectre/linux/.config: not affected
Config: /home/spectre/linux/.config not affected
```