### PR TITLE
Parse coccinelle output and add files and lines to report

### DIFF
--- a/cvehound/__init__.py
+++ b/cvehound/__init__.py
@@ -14,7 +14,7 @@ from sympy.logic import simplify_logic
 from sympy import symbols
 from cvehound.cpu import CPU
 from cvehound.exception import UnsupportedVersion
-from cvehound.util import get_spatch_version, get_rule_cves, get_cves_metadata
+from cvehound.util import get_spatch_version, get_rule_cves, get_cves_metadata, parse_coccinelle_output
 from cvehound.kbuild import KbuildParser
 from cvehound.config import Config
 
@@ -218,7 +218,7 @@ class CVEhound:
                         result_file['logic'] = str(True)
                         result_file['config'] = True
                         config_affected = True
-                    elif file.endswith('.h'): # FIXME: only .h file? 
+                    elif file.endswith('.h'): # FIXME: only .h file?
                         result_file['logic'] = str(True)
                         result_file['config'] = True
                         config_affected = True
@@ -231,6 +231,7 @@ class CVEhound:
                 result = self.metadata[cve]
             result['config'] = config_result
             result['spatch_output'] = output
+            result['files'] = parse_coccinelle_output(output)
             self._print_found_cve(cve)
             self._print_affected_files(config_result)
             logging.debug(output)

--- a/cvehound/util.py
+++ b/cvehound/util.py
@@ -80,3 +80,13 @@ def get_cves_metadata():
     with gzip.open(cves, 'rt', encoding='utf-8') as fh:
         data = json.load(fh)
     return data
+
+def parse_coccinelle_output(output):
+    files = []
+    for line in output.splitlines():
+        file, hline, _ = line.split(':', 2)
+        files.append({
+            'file': file,
+            'line': int(hline),
+        })
+    return files


### PR DESCRIPTION
Adds `files` field to json output
```
    "results": {
        "CVE-2022-1651": {
            "affected_versions": "unk to v5.18-rc1",
            "breaks": "",
            "cmt_msg": "virt: acrn: fix a memory leak in acrn_dev_ioctl()",
            "config": {},
            "exploit": false,
            "files": [
                {
                    "file": "linux/drivers/virt/acrn/hsm.c",
                    "line": 140
                },
                {
                    "file": "linux/drivers/virt/acrn/hsm.c",
                    "line": 186
                },
                {
                    "file": "linux/drivers/virt/acrn/hsm.c",
                    "line": 190
                },
                {
                    "file": "linux/drivers/virt/acrn/hsm.c",
                    "line": 194
                },
                {
                    "file": "linux/drivers/virt/acrn/hsm.c",
                    "line": 199
                }
            ],
...
```