### PR TITLE
Custom metadata path and config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ sources for all cve patterns that you can find in [cve dir](/cvehound/cve/).
 To check the sources for particular CVEs one can use:
 
 ``` shell
-$ cvehound --kernel ./linux --config --cve CVE-2020-27194 CVE-2020-29371
+$ cvehound --kernel ./linux --kernel-config --cve CVE-2020-27194 CVE-2020-29371
 Checking: CVE-2020-27194
 Found: CVE-2020-27194
 MSG: bpf: Fix scalar32_min_max_or bounds tracking
@@ -114,7 +114,7 @@ Config: ./linux/.config not affected
 Other args:
  - `--report` - will produce json file with found CVEs
    Most of metainformation in generated report is taken from linuxkernelcves.com
- - `--config` or `--config <file>` - will infer the kernel configuration required to
+ - `--kernel-config` or `--kernel-config <file>` - will infer the kernel configuration required to
    build the affected code (based on Kbuild/Makefiles, ifdefs are not checked) and
    check kernel .config file if there is one
  - `--files`, `--cwe` - will limit the scope of checked cves to the kernel files of

--- a/cvehound/__init__.py
+++ b/cvehound/__init__.py
@@ -23,10 +23,10 @@ __VERSION__ = '1.0.9'
 
 class CVEhound:
 
-    def __init__(self, kernel, config=None, check_strict=False, arch='x86'):
+    def __init__(self, kernel, metadata=None, config=None, check_strict=False, arch='x86'):
         kernel = os.path.abspath(kernel)
         self.kernel = kernel
-        self.metadata = get_cves_metadata(None)
+        self.metadata = get_cves_metadata(metadata)
         self.cocci_job = str(CPU().get_cocci_jobs())
         self.spatch_version = get_spatch_version()
         self.check_strict = check_strict

--- a/cvehound/__init__.py
+++ b/cvehound/__init__.py
@@ -26,7 +26,7 @@ class CVEhound:
     def __init__(self, kernel, config=None, check_strict=False, arch='x86'):
         kernel = os.path.abspath(kernel)
         self.kernel = kernel
-        self.metadata = get_cves_metadata()
+        self.metadata = get_cves_metadata(None)
         self.cocci_job = str(CPU().get_cocci_jobs())
         self.spatch_version = get_spatch_version()
         self.check_strict = check_strict

--- a/cvehound/__main__.py
+++ b/cvehound/__main__.py
@@ -45,6 +45,8 @@ def main(args=sys.argv[1:]):
                         help='output report with found CVEs')
     parser.add_argument('--all-files', action='store_true',
                         help="don't use files hint from cocci rules")
+    parser.add_argument('--metadata', metavar='PATH',
+                        help="Path to non-standard location of kernel_cves.json.gz")
     parser.add_argument('--version', action='version', version=get_cvehound_version())
     cmdargs = parser.parse_args()
 
@@ -57,6 +59,14 @@ def main(args=sys.argv[1:]):
         parser.print_usage()
         print("cvehound: error: the following arguments are required: --kernel/-k", file=sys.stderr)
         sys.exit(1)
+
+    if cmdargs.metadata:
+        if not os.path.isfile(cmdargs.metadata):
+            print("Can't find metadata file", cmdargs.metadata, file=sys.stderr)
+            sys.exit(1)
+        if not cmdargs.metadata.endswith('.gz'):
+            print("Metadata file", cmdargs.metadata, "is not the gz archive", file=sys.stderr)
+            sys.exit(1)
 
     if not all(os.path.isfile(os.path.join(cmdargs.kernel, f)) for f in
                ['Makefile']):
@@ -91,7 +101,8 @@ def main(args=sys.argv[1:]):
     if cmdargs.config and cmdargs.config != '-':
         config_info = get_config_data(cmdargs.config)
 
-    hound = CVEhound(cmdargs.kernel, cmdargs.config, cmdargs.check_strict, config_info.get('arch', 'x86'))
+    hound = CVEhound(cmdargs.kernel, cmdargs.metadata, cmdargs.config,
+                     cmdargs.check_strict, config_info.get('arch', 'x86'))
 
     cve_id = re.compile(r'^CVE-\d{4}-\d{4,7}$')
     if cmdargs.cve == ['all']:

--- a/cvehound/__main__.py
+++ b/cvehound/__main__.py
@@ -37,7 +37,7 @@ def main(args=sys.argv[1:]):
                         help='check only files (e.g. kernel drivers/block/floppy.c arch/x86)')
     parser.add_argument('--ignore-files', nargs='+', default=[], metavar='PATH',
                         help='exclude kernel files from check (e.g. kernel/bpf)')
-    parser.add_argument('--config', nargs='?', const='-', metavar='.config',
+    parser.add_argument('--kernel-config', nargs='?', const='-', metavar='.config',
                         help='check kernel config')
     parser.add_argument('--check-strict', action='store_true',
                         help='output only CVEs enabled in .config')
@@ -73,21 +73,21 @@ def main(args=sys.argv[1:]):
         print(cmdargs.kernel, "isn't a kernel directory", file=sys.stderr)
         sys.exit(1)
 
-    if cmdargs.config == '-':
+    if cmdargs.kernel_config == '-':
         config = os.path.normpath(os.path.join(cmdargs.kernel, '.config'))
         if os.path.isfile(config):
-            cmdargs.config = config
+            cmdargs.kernel_config = config
     else:
-        if cmdargs.config and not os.path.isfile(cmdargs.config):
-            print("Can't find config file", cmdargs.config, file=sys.stderr)
+        if cmdargs.kernel_config and not os.path.isfile(cmdargs.kernel_config):
+            print("Can't find config file", cmdargs.kernel_config, file=sys.stderr)
             sys.exit(1)
 
-    if cmdargs.config and cmdargs.verbose == 0:
+    if cmdargs.kernel_config and cmdargs.verbose == 0:
         cmdargs.verbose = 1
 
     if cmdargs.check_strict:
-        if not cmdargs.config:
-            print('Please, use --check-strict with --config', file=sys.stderr)
+        if not cmdargs.kernel_config:
+            print('Please, use --check-strict with --kernel-config', file=sys.stderr)
             sys.exit(1)
 
     loglevel = logging.WARNING
@@ -98,10 +98,10 @@ def main(args=sys.argv[1:]):
     logging.basicConfig(level=loglevel, format='%(message)s')
 
     config_info = {}
-    if cmdargs.config and cmdargs.config != '-':
-        config_info = get_config_data(cmdargs.config)
+    if cmdargs.kernel_config and cmdargs.kernel_config != '-':
+        config_info = get_config_data(cmdargs.kernel_config)
 
-    hound = CVEhound(cmdargs.kernel, cmdargs.metadata, cmdargs.config,
+    hound = CVEhound(cmdargs.kernel, cmdargs.metadata, cmdargs.kernel_config,
                      cmdargs.check_strict, config_info.get('arch', 'x86'))
 
     cve_id = re.compile(r'^CVE-\d{4}-\d{4,7}$')
@@ -180,13 +180,13 @@ def main(args=sys.argv[1:]):
     report = { 'args': {}, 'kernel': {}, 'config': {}, 'tools': {}, 'results': {}}
     report['args']['cve'] = cmdargs.cve
     report['args']['kernel'] = cmdargs.kernel
-    report['args']['config'] = cmdargs.config
+    report['args']['config'] = cmdargs.kernel_config
     report['args']['only_cwe'] = cmdargs.cwe
     report['args']['only_files'] = cmdargs.files
     report['args']['all_files'] = cmdargs.all_files
     report['args']['check_strict'] = cmdargs.check_strict
     report['kernel'] = get_kernel_version(cmdargs.kernel)
-    if cmdargs.config != '-':
+    if cmdargs.kernel_config != '-':
         report['config'] = config_info
     report['tools']['cvehound'] = get_cvehound_version()
     report['tools']['spatch'] = '.'.join(list(str(get_spatch_version())))

--- a/cvehound/scripts/update_metadata.py
+++ b/cvehound/scripts/update_metadata.py
@@ -52,12 +52,16 @@ def get_commit_date(repo, commit):
 
 def main(args=sys.argv):
     if len(args) < 2 or not os.path.isdir(os.path.join(args[1], '.git')):
-        print('Usage: {} <kernel_repo_dir>'.format(args[0]), file=sys.stderr)
-        exit(1)
+        print('Usage: {} <kernel_repo_dir> [metadata_file]'.format(args[0]), file=sys.stderr)
+        sys.exit(1)
     repo = args[1]
 
-    filename = os.environ.get('CVEHOUND_METADATA',
-                              pkg_resources.resource_filename('cvehound', 'data/kernel_cves.json.gz'))
+    filename = None
+    if len(args) == 3:
+        filename = args[2]
+    else:
+        filename = os.environ.get('CVEHOUND_METADATA',
+                                  pkg_resources.resource_filename('cvehound', 'data/kernel_cves.json.gz'))
 
     public, private = get_exploit_status_from_fstec()
 

--- a/cvehound/scripts/update_metadata.py
+++ b/cvehound/scripts/update_metadata.py
@@ -55,7 +55,9 @@ def main(args=sys.argv):
         print('Usage: {} <kernel_repo_dir>'.format(args[0]), file=sys.stderr)
         exit(1)
     repo = args[1]
-    filename = pkg_resources.resource_filename('cvehound', 'data/kernel_cves.json.gz')
+
+    filename = os.environ.get('CVEHOUND_METADATA',
+                              pkg_resources.resource_filename('cvehound', 'data/kernel_cves.json.gz'))
 
     public, private = get_exploit_status_from_fstec()
 

--- a/cvehound/util.py
+++ b/cvehound/util.py
@@ -74,10 +74,12 @@ def get_rule_cves():
                 assigned[name] = path
     return (known, assigned, disputed)
 
-def get_cves_metadata():
-    cves = pkg_resources.resource_filename('cvehound', 'data/kernel_cves.json.gz')
+def get_cves_metadata(path):
+    if not path:
+        path = os.environ.get('CVEHOUND_METADATA',
+               pkg_resources.resource_filename('cvehound', 'data/kernel_cves.json.gz'))
     data = None
-    with gzip.open(cves, 'rt', encoding='utf-8') as fh:
+    with gzip.open(path, 'rt', encoding='utf-8') as fh:
         data = json.load(fh)
     return data
 


### PR DESCRIPTION
 - `CVEHOUND_METADATA` env var for overwriting default location of a metadata file
 - `--metadata` command line argument for specifying location of a metadata file
 - `--config` option for cvehound.ini file with default values for command line arguments support of system configuration file `/etc/cvehound.ini` and user configuration file `$HOME/.config/cvehound.ini`