### PR TITLE
Support Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-18.04, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,8 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9'
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
     packages=[
         'cvehound',


### PR DESCRIPTION
Note that due to this [issue](https://github.com/actions/setup-python/issues/160), we need to use quotes around Python versions.