### PR TITLE
fix bug

### DIFF
--- a/cvehound/__main__.py
+++ b/cvehound/__main__.py
@@ -159,7 +159,7 @@ def main(args=sys.argv[1:]):
 
     cve_id = re.compile(r'^CVE-\d{4}-\d{4,7}$')
     if args['cve'] == ['all']:
-        args.cve = hound.get_all_cves()
+        args['cve'] = hound.get_all_cves()
     elif args['cve'] == ['assigned']:
         args['cve'] = hound.get_assigned_cves()
     elif args['cve'] == ['disputed']:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/firmy/.local/bin/cvehound", line 8, in <module>
    sys.exit(main())
  File "/home/firmy/.local/lib/python3.8/site-packages/cvehound/__main__.py", line 162, in main
    args.cve = hound.get_all_cves()
AttributeError: 'dict' object has no attribute 'cve'
```