### PR TITLE
Update GitHub Actions publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,5 @@
-# This workflows will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 
 name: Upload Python Package
 
@@ -14,18 +14,25 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
+
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
         python-version: '3.x'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Build and publish
+        pip install build twine
+
+    - name: Build package
+      run: python -m build
+
+    - name: Check package
+      run: twine check dist/*
+
+    - name: Publish to PyPI
       env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: twine upload dist/*


### PR DESCRIPTION
- Replace deprecated 'python setup.py' with 'python -m build'
- Update authentication to use PyPI API token instead of username/password
- Add package verification step with 'twine check'
- Update dependencies: replace 'setuptools wheel' with 'build'
- Improve workflow structure with separate build and publish steps
- Update documentation URL to current packaging guide