### PR TITLE
feat: confine scans with landlock and seccomp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,5 +192,12 @@ downloads it into the cache dir when the checkout has none. Precedence at runtim
 `--metadata` → `$CVEHOUND_METADATA` → overlay → packaged. CLI defaults can also come
 from `/etc/cvehound.ini` or `~/.config/cvehound.ini` (`--config`).
 
+`cvehound/sandbox.py` confines a scan with Landlock and seccomp (pure `ctypes`, no new
+dependency). Its install point in `__main__.py`, immediately before the pool, is
+load-bearing rather than incidental: both mechanisms are inherited across fork *and*
+execve, so one call there covers the workers, every spatch, and everything spatch shells
+out to — but only while no thread or child exists yet. The module's own docstring covers
+the rest, including why a too-tight policy fails silently.
+
 When a rule is a judgement call, prefer a false positive: a missed CVE is worse than a
 noisy one.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,23 @@
 # ChangeLog
 
+## Unreleased
+
+ - Scans are now sandboxed by default. Landlock confines the run to the kernel tree (read-only),
+   the rules and a temp directory with no network, and a seccomp filter closes what Landlock
+   structurally cannot express -- UDP and netlink sockets, io_uring, ptrace, namespace syscalls.
+   Both are installed once just before the worker pool, so they cover the workers, every spatch,
+   and the /bin/sh, git, find, rm and diff that spatch shells out to. --sandbox=off skips it,
+   --sandbox=strict refuses to scan when the kernel cannot provide it, and the default falls back
+   to an unconfined scan on a kernel without Landlock. A self-test runs after the lock: an
+   over-tight policy would otherwise show up as "0 files match" rather than as an error
+ - spatch now runs with GIT_CONFIG_GLOBAL=/dev/null and GIT_CONFIG_NOSYSTEM=1. Handed a directory
+   it prefilters by shelling out to `git grep`, and that git was reading the user's ~/.gitconfig,
+   so a setting there could change what a scan found on one machine but not another. cvehound
+   supplies safe.directory for the scanned tree over GIT_CONFIG_* (the "command" scope, which git
+   treats as protected), so a checkout owned by another user still scans -- previously that needed
+   the user's own git config, and without it git refused the repository and spatch reported
+   "0 files match" with exit 0
+
 ## 1.5.0 - Aug 27 2026
 
  - spatch runs are now bounded by two time budgets instead of none: SPATCH_TIMEOUT (CPU-seconds,

--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ Other args:
  - `--files` - will limit the scope of checked cves to the kernel files of interest
  - `--exploit` - check only for CVEs that are known to be exploitable (according to
    the CISA Known Exploited Vulnerabilities catalog)
+ - `--sandbox` - `auto` (default), `off`, or `strict`. Confines the scan with Landlock and
+   seccomp so a detection rule cannot reach past the tree it is scanning: the kernel tree
+   is read-only, your home directory and the network are unreachable, and only a temp
+   directory is writable. `auto` falls back to an unconfined scan when the kernel cannot
+   do it (Landlock needs 5.13+, enabled at boot) and says so under `--verbose`; `strict`
+   refuses to scan instead. `$CVEHOUND_SANDBOX` sets the default.
 
 ## Contributing
 

--- a/cvehound/__init__.py
+++ b/cvehound/__init__.py
@@ -115,18 +115,73 @@ def evaluate_file_condition(
     return (text, affected if config is not None else None)
 
 
-def _spatch_env() -> dict[str, str]:
-    """The environment for a spatch child: ours, plus our GC defaults.
+def _spatch_env(kernel: str | None = None) -> dict[str, str]:
+    """The environment for a spatch child: ours, plus our GC and git defaults.
 
     A caller who has already said something about the OCaml runtime keeps it
     untouched -- the tuning is a default, not a policy. CAMLRUNPARAM counts as
     saying something: the runtime reads OCAMLRUNPARAM first and only falls back
     to it, so setting ours unconditionally would silently void theirs.
+
+    The git half is about reproducibility. Handed a directory, spatch prefilters
+    it by shelling out to `git grep` once per rule token, and that git reads the
+    user's ~/.gitconfig and /etc/gitconfig -- so a grep.* or pathspec setting
+    there can change what a scan finds, on one machine and not another. Dropping
+    both makes the prefilter a function of the tree alone.
+
+    Dropping them alone would strand a tree owned by someone else, though -- a
+    root-checked-out CI image, a shared mirror -- because git refuses to work in
+    one unless safe.directory names it, and honours safe.directory only from
+    protected configuration. So we supply it rather than defer: GIT_CONFIG_* is
+    the "command" scope, which is protected (git >= 2.38), and naming one exact
+    realpath is not the blanket bypass safe.directory=* would be. Appending past
+    a caller's own GIT_CONFIG_COUNT leaves their entries intact.
+
+    Getting this wrong is expensive and quiet: a git that cannot open the tree
+    makes spatch print "0 files match" and exit 0, so every CVE reads as absent.
     """
     env = dict(os.environ)
     if 'OCAMLRUNPARAM' not in env and 'CAMLRUNPARAM' not in env:
         env['OCAMLRUNPARAM'] = SPATCH_OCAMLRUNPARAM
+    env.setdefault('GIT_CONFIG_GLOBAL', os.devnull)
+    env.setdefault('GIT_CONFIG_NOSYSTEM', '1')
+    if kernel:
+        try:
+            count = int(env.get('GIT_CONFIG_COUNT') or 0)
+        except ValueError:
+            count = 0
+        env[f'GIT_CONFIG_KEY_{count}'] = 'safe.directory'
+        env[f'GIT_CONFIG_VALUE_{count}'] = os.path.realpath(kernel)
+        env['GIT_CONFIG_COUNT'] = str(count + 1)
     return env
+
+
+def check_git_prefilter(kernel: str) -> list[str]:
+    """Whether git can still open the tree, when spatch is going to ask it to.
+
+    Handed a git directory spatch prefilters with `git grep`, and a git that
+    cannot open the repository exits non-zero -- which spatch reports as "0 files
+    match" and exit 0. Repo discovery is the part that fails (an unreadable
+    config, an ownership check), so `rev-parse` proves it without walking the
+    tree. It lives here, next to the environment it has to run under, because
+    that environment is the thing most likely to break it.
+    """
+    if not os.path.isdir(os.path.join(kernel, '.git')):
+        return []
+    try:
+        run = subprocess.run(
+            ['git', 'rev-parse', '--show-toplevel'],
+            cwd=kernel,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=_spatch_env(kernel),
+        )
+    except OSError as err:
+        return [f'cannot run git in {kernel}: {err}']
+    if run.returncode != 0:
+        return [f'git cannot open {kernel}: {run.stderr.strip() or run.returncode}']
+    return []
 
 
 def _run_spatch(cve: str, kernel: str, cmd: list[str], wall_timeout: int) -> str:
@@ -147,7 +202,7 @@ def _run_spatch(cve: str, kernel: str, cmd: list[str], wall_timeout: int) -> str
         stderr=subprocess.PIPE,
         text=True,
         start_new_session=True,
-        env=_spatch_env(),
+        env=_spatch_env(kernel),
     ) as proc:
         try:
             # 0 disables the watchdog, matching what spatch reads --timeout 0 as.

--- a/cvehound/__main__.py
+++ b/cvehound/__main__.py
@@ -2,6 +2,7 @@
 
 import argparse
 import concurrent.futures
+import contextlib
 import json
 import logging
 import multiprocessing
@@ -14,7 +15,14 @@ from typing import Any
 
 from cvehound import SPATCH_TIMEOUT, SPATCH_WALL_TIMEOUT, CVEhound
 from cvehound.content import resolve_content
-from cvehound.exception import SpatchError, SpatchNotFound, SpatchTimeout, UnsupportedVersion
+from cvehound.exception import (
+    SandboxError,
+    SpatchError,
+    SpatchNotFound,
+    SpatchTimeout,
+    UnsupportedVersion,
+)
+from cvehound.sandbox import install as install_sandbox
 from cvehound.util import (
     find_spatch,
     fix_date_str,
@@ -32,6 +40,8 @@ from cvehound.worker import _worker_check_cve, _worker_init, setup_logging
 
 # Metadata older than this gets a warning; --exploit is stricter because the
 # CISA KEV catalog it filters on changes much faster than the fix data.
+SANDBOX_MODES = ('auto', 'off', 'strict')
+
 METADATA_STALE_DAYS = 90
 METADATA_STALE_DAYS_EXPLOIT = 30
 
@@ -196,6 +206,7 @@ def check_config(config: dict[str, Any]) -> None:
         'metadata',
         'arch',
         'spatch',
+        'sandbox',
     }
     diff = set(config.keys()) - valid_config_options
     if diff:
@@ -286,6 +297,14 @@ def main(args: list[str] | None = None) -> None:
         ' cvehound-spatch package, then PATH)',
     )
     parser.add_argument(
+        '--sandbox',
+        choices=SANDBOX_MODES,
+        default=os.environ.get('CVEHOUND_SANDBOX', 'auto'),
+        help='confine the scan with landlock and seccomp: auto falls back to an'
+        ' unconfined scan when the kernel cannot do it, strict refuses to scan'
+        ' (default: $CVEHOUND_SANDBOX, else auto)',
+    )
+    parser.add_argument(
         '--version',
         action=_VersionAction,
         default=argparse.SUPPRESS,
@@ -320,6 +339,18 @@ def main(args: list[str] | None = None) -> None:
         if cmdargs_dict[arg] != parser.get_default(arg) or arg not in merged_args:
             merged_args[arg] = cmdargs_dict[arg]
     args_cfg = merged_args
+
+    # argparse checks `choices` only for a value it parsed off the command line:
+    # $CVEHOUND_SANDBOX supplies the default and cvehound.ini overrides it, so
+    # neither is validated. Untreated, 'Off' or 'no' would read as "not off" and
+    # confine a scan the user asked to leave alone.
+    if args_cfg['sandbox'] not in SANDBOX_MODES:
+        print(
+            'Wrong --sandbox value:',
+            args_cfg['sandbox'] + ' (expected ' + ', '.join(SANDBOX_MODES) + ')',
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     if not args_cfg['kernel']:
         parser.print_usage()
@@ -534,10 +565,71 @@ def main(args: list[str] | None = None) -> None:
         'latest_fix_date': fix_date_str(latest_fix) if latest_fix else None,
     }
 
-    # Under forkserver (the Linux default since Python 3.14) workers would
-    # otherwise each re-import cvehound (and sympy) when the CLI runs as
-    # `python -m cvehound`; preloading amortizes that once. No-op for fork/spawn.
-    multiprocessing.set_forkserver_preload(['cvehound.worker'])
+    # Opened before the sandbox closes over the filesystem, and written through
+    # this fd at the end: Landlock leaves an already-open fd alone, whereas
+    # granting the report's directory would mean write access to the CWD, which is
+    # routinely $HOME. No O_TRUNC either -- a run that dies partway should leave
+    # the previous report in place rather than an empty file.
+    report_fd = None
+    created_report = False
+    if args_cfg['report']:
+        created_report = not os.path.exists(args_cfg['report'])
+        try:
+            report_fd = os.open(args_cfg['report'], os.O_WRONLY | os.O_CREAT | os.O_CLOEXEC, 0o666)
+        except OSError as err:
+            print("Can't open report file:", err, file=sys.stderr)
+            sys.exit(1)
+
+    try:
+        # Last thing before the pool, and that is the whole trick: no thread and
+        # no child exists yet, so the one call covers the workers, the spatch each
+        # of them runs, and the /bin/sh, git, find, rm and diff spatch runs in turn.
+        if args_cfg['sandbox'] != 'off':
+            try:
+                install_sandbox(
+                    args_cfg['kernel'],
+                    content.rules_dir,
+                    hound.spatch,
+                    metadata_path,
+                    strict=args_cfg['sandbox'] == 'strict',
+                )
+            except SandboxError as err:
+                print(err, file=sys.stderr)
+                sys.exit(1)
+
+        # Under forkserver (the Linux default since Python 3.14) workers would
+        # otherwise each re-import cvehound (and sympy) when the CLI runs as
+        # `python -m cvehound`; preloading amortizes that once. No-op for fork/spawn.
+        multiprocessing.set_forkserver_preload(['cvehound.worker'])
+        run_scan(hound, args_cfg, loglevel, cves_sorted, report)
+
+        if report_fd is not None:
+            with os.fdopen(report_fd, 'w', encoding='utf-8') as fh:
+                fh.truncate(0)
+                json.dump(report, fh, indent=4, sort_keys=True)
+    except BaseException:
+        # The pre-open created this file before anything was scanned, so every way
+        # out of the block above -- a refused sandbox, Ctrl-C, a dead pool, a
+        # half-written report -- has to take it back with it. An empty report.json
+        # parses worse than no report.json.
+        if report_fd is not None and created_report:
+            with contextlib.suppress(OSError):
+                os.close(report_fd)
+            with contextlib.suppress(OSError):
+                os.unlink(args_cfg['report'])
+        raise
+    if report_fd is not None:
+        print('Report saved to:', args_cfg['report'])
+
+
+def run_scan(
+    hound: CVEhound,
+    args_cfg: dict[str, Any],
+    loglevel: int,
+    cves_sorted: list[str],
+    report: dict[str, Any],
+) -> None:
+    """Fan the CVEs out over the pool and fold the results into the report."""
     with concurrent.futures.ProcessPoolExecutor(
         max_workers=os.cpu_count(), initializer=_worker_init, initargs=(hound, loglevel)
     ) as executor:
@@ -575,11 +667,6 @@ def main(args: list[str] | None = None) -> None:
                     'error': 'unsupported_version',
                     'requires': err.rule_version,
                 }
-
-    if args_cfg['report']:
-        with open(args_cfg['report'], 'w', encoding='utf-8') as fh:
-            json.dump(report, fh, indent=4, sort_keys=True)
-        print('Report saved to:', args_cfg['report'])
 
 
 if __name__ == '__main__':

--- a/cvehound/exception.py
+++ b/cvehound/exception.py
@@ -97,3 +97,24 @@ class SpatchTimeout(SpatchError):
 
     def __reduce__(self) -> tuple[Any, tuple[Any, ...]]:
         return (self.__class__, super().__reduce__()[1] + (self.timeout, self.files, self.wall))
+
+
+class SandboxError(Exception):
+    """The sandbox could not be installed, or could not be trusted once it was.
+
+    Raised for two situations that both have to stop the scan. Under --sandbox
+    strict, any degradation at all. And always, a self-test that failed after
+    landlock_restrict_self: the policy is one path too tight, Landlock cannot be
+    undone, and continuing would report a clean kernel rather than an error --
+    spatch answers "0 files match" whether a tree is clean or unreadable.
+    """
+
+    def __init__(self, reasons: list[str]) -> None:
+        self.reasons = reasons
+        super().__init__(self._summary())
+
+    def _summary(self) -> str:
+        return 'sandbox failed:\n  ' + '\n  '.join(self.reasons)
+
+    def __reduce__(self) -> tuple[Any, tuple[Any, ...]]:
+        return (self.__class__, (self.reasons,))

--- a/cvehound/sandbox.py
+++ b/cvehound/sandbox.py
@@ -1,0 +1,628 @@
+#!/usr/bin/env python3
+
+"""Bound what a scan may touch, the way the timeouts bound how long it may run.
+
+A scan hands an untrusted source tree to spatch -- a large OCaml binary driven by
+.cocci rules that `cvehound update` fetches over the network -- and spatch is not
+a leaf process. Traced under this tool's own argv it shells out:
+
+    /bin/sh -c "cd DIR > /dev/null; git grep -l -w TOKEN -- '*.[ch]'"   per rule token
+    /bin/sh -c "find DIR -type f -name '*.[ch]' ..."                    non-git trees
+    /bin/sh -c "rm -rf TMPDIR"                                          --tmp-dir cleanup
+    /bin/sh -c "diff -u -p ..."                                         on a match
+
+None of that needs the user's ssh keys, their home directory, or a socket. Landlock
+takes away the filesystem and TCP; seccomp takes away the syscalls Landlock cannot
+express (UDP, netlink, io_uring, ptrace, namespaces). Both are inherited across fork
+and execve, so installing once in the parent covers the worker pool, spatch, and
+everything spatch runs.
+
+Two properties drive the shape of this module:
+
+Landlock is irreversible. Every way of *not* sandboxing has to be decided before
+landlock_restrict_self, which is why apply() degrades but self_test() aborts.
+
+A too-tight policy is silent. Denied a path it needs, spatch reports "0 files match"
+and exits 0 -- a missed CVE that looks exactly like a clean tree. That is the failure
+mode this module exists to avoid, so self_test() proves the allowed set positively
+rather than trusting that the rules were built right.
+"""
+
+import ctypes
+import logging
+import os
+import platform
+import site
+import sys
+import tempfile
+from dataclasses import dataclass, field
+
+from cvehound import check_git_prefilter
+from cvehound.exception import SandboxError
+
+# The constants below are uapi values with no Python equivalent, so they have to
+# be written out. tests/test_15_sandbox.py checks every one of them against this
+# machine's own kernel headers via the C preprocessor, so a transcription error
+# fails the suite rather than silently confining the wrong thing.
+#
+# Same numbers on every architecture (the syscalls were added in one block).
+_NR_LANDLOCK_CREATE_RULESET = 444
+_NR_LANDLOCK_ADD_RULE = 445
+_NR_LANDLOCK_RESTRICT_SELF = 446
+
+_PR_SET_NO_NEW_PRIVS = 38
+_LANDLOCK_CREATE_RULESET_VERSION = 1 << 0
+_LANDLOCK_RULE_PATH_BENEATH = 1
+
+# LANDLOCK_ACCESS_FS_* in uapi bit order; the index is the bit.
+_FS_RIGHTS = (
+    'EXECUTE',
+    'WRITE_FILE',
+    'READ_FILE',
+    'READ_DIR',
+    'REMOVE_DIR',
+    'REMOVE_FILE',
+    'MAKE_CHAR',
+    'MAKE_DIR',
+    'MAKE_REG',
+    'MAKE_SOCK',
+    'MAKE_FIFO',
+    'MAKE_BLOCK',
+    'MAKE_SYM',
+    'REFER',
+    'TRUNCATE',
+    'IOCTL_DEV',
+)
+FS = {name: 1 << bit for bit, name in enumerate(_FS_RIGHTS)}
+
+# Highest FS bit an ABI knows. Asking for a bit the running kernel has never heard
+# of fails the whole ruleset, so the request is always clamped to this -- including
+# on a kernel newer than the table, where the right move is to ask for what we
+# understand rather than to guess at what was added.
+_ABI_FS_LAST = {1: 12, 2: 13, 3: 14, 4: 14, 5: 15}
+_ABI_FS_LAST_KNOWN = max(_ABI_FS_LAST.values())
+
+# Rights that mean nothing on a non-directory. Landlock rejects the whole rule with
+# EINVAL rather than ignoring them, so a rule for /dev/null has to be masked down.
+_FILE_RIGHTS = FS['EXECUTE'] | FS['WRITE_FILE'] | FS['READ_FILE'] | FS['TRUNCATE'] | FS['IOCTL_DEV']
+
+_NET_BIND_TCP = 1 << 0
+_NET_CONNECT_TCP = 1 << 1
+_SCOPE_ABSTRACT_UNIX_SOCKET = 1 << 0
+_SCOPE_SIGNAL = 1 << 1
+
+# landlock_ruleset_attr grew a field at a time, and the kernel rejects a struct
+# longer than the one it knows with non-zero tail bytes. Send exactly as much as
+# the running ABI can read.
+_ATTR_SIZE_FS = 8
+_ATTR_SIZE_NET = 16
+_ATTR_SIZE_SCOPED = 24
+
+_NR_SECCOMP = {'x86_64': 317, 'aarch64': 277}
+_AUDIT_ARCH = {'x86_64': 0xC000003E, 'aarch64': 0xC00000B7}
+
+_BPF_LD_W_ABS = 0x20
+_BPF_JMP_JEQ_K = 0x15
+_BPF_JMP_JGE_K = 0x35
+_BPF_RET_K = 0x06
+
+_X32_SYSCALL_BIT = 0x40000000
+_SECCOMP_RET_KILL_PROCESS = 0x80000000
+_SECCOMP_RET_ERRNO = 0x00050000
+_SECCOMP_RET_ALLOW = 0x7FFF0000
+_SECCOMP_SET_MODE_FILTER = 1
+_SECCOMP_FILTER_FLAG_TSYNC = 1
+
+# Offsets into struct seccomp_data: nr, arch, then args[0] after the 8-byte
+# instruction pointer. Little-endian, so args[0]'s low word is at its base.
+_OFF_NR = 0
+_OFF_ARCH = 4
+_OFF_ARG0 = 16
+
+_AF_UNIX = 1
+_EPERM = 1
+_EAFNOSUPPORT = 97
+
+# Denied outright. Every one of these is something Landlock structurally cannot
+# reach -- it governs files and TCP, not syscall families -- and none of them appear
+# in a traced spatch subtree, whose whole vocabulary is 58 syscalls. The ones that
+# matter most here are the socket families (Landlock sees TCP only, so UDP is an
+# open exfil path), io_uring (its own submission path has historically bypassed
+# per-syscall checks), and ptrace (Landlock stops crossing *out* of a domain, not
+# one sandboxed process reading another's memory).
+_DENY = {
+    'x86_64': {
+        'ptrace': 101,
+        'process_vm_readv': 310,
+        'process_vm_writev': 311,
+        'unshare': 272,
+        'setns': 308,
+        'mount': 165,
+        'umount2': 166,
+        'pivot_root': 155,
+        'chroot': 161,
+        'bpf': 321,
+        'perf_event_open': 298,
+        'userfaultfd': 323,
+        'io_uring_setup': 425,
+        'io_uring_enter': 426,
+        'io_uring_register': 427,
+        'add_key': 248,
+        'request_key': 249,
+        'keyctl': 250,
+        'init_module': 175,
+        'finit_module': 313,
+        'delete_module': 176,
+        'kexec_load': 246,
+        'kexec_file_load': 320,
+    },
+    'aarch64': {
+        'ptrace': 117,
+        'process_vm_readv': 270,
+        'process_vm_writev': 271,
+        'unshare': 97,
+        'setns': 268,
+        'mount': 40,
+        'umount2': 39,
+        'pivot_root': 41,
+        'chroot': 51,
+        'bpf': 280,
+        'perf_event_open': 241,
+        'userfaultfd': 282,
+        'io_uring_setup': 425,
+        'io_uring_enter': 426,
+        'io_uring_register': 427,
+        'add_key': 217,
+        'request_key': 218,
+        'keyctl': 219,
+        'init_module': 105,
+        'finit_module': 273,
+        'delete_module': 106,
+        'kexec_load': 104,
+        'kexec_file_load': 294,
+    },
+}
+_NR_SOCKET = {'x86_64': 41, 'aarch64': 198}
+
+_libc = ctypes.CDLL(None, use_errno=True)
+_libc.syscall.restype = ctypes.c_long
+
+
+class _RulesetAttr(ctypes.Structure):
+    _fields_ = (
+        ('handled_access_fs', ctypes.c_uint64),
+        ('handled_access_net', ctypes.c_uint64),
+        ('scoped', ctypes.c_uint64),
+    )
+
+
+class _PathBeneathAttr(ctypes.Structure):
+    # Packed in the uapi header, and landlock_add_rule takes no size argument, so
+    # the 12-byte layout is not negotiable -- natural alignment would send 16 and
+    # put parent_fd in the padding.
+    _pack_ = 1
+    _layout_ = 'ms'
+    _fields_ = (('allowed_access', ctypes.c_uint64), ('parent_fd', ctypes.c_int32))
+
+
+class _SockFilter(ctypes.Structure):
+    _fields_ = (
+        ('code', ctypes.c_uint16),
+        ('jt', ctypes.c_uint8),
+        ('jf', ctypes.c_uint8),
+        ('k', ctypes.c_uint32),
+    )
+
+
+class _SockFprog(ctypes.Structure):
+    _fields_ = (('len', ctypes.c_uint16), ('filter', ctypes.POINTER(_SockFilter)))
+
+
+@dataclass(frozen=True)
+class SandboxPolicy:
+    """The three access classes, as absolute paths. Missing paths are dropped."""
+
+    read: tuple[str, ...] = ()
+    read_exec: tuple[str, ...] = ()
+    write: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class SandboxStatus:
+    """What actually got installed, for the log line and for --sandbox=strict."""
+
+    landlock_abi: int = 0
+    seccomp: bool = False
+    degraded: tuple[str, ...] = field(default_factory=tuple)
+
+    def summary(self) -> str:
+        parts = []
+        if self.landlock_abi:
+            parts.append(f'landlock ABI {self.landlock_abi}')
+        if self.seccomp:
+            parts.append('seccomp')
+        line = 'sandbox: ' + (' + '.join(parts) or 'off')
+        if self.degraded:
+            line += ' (' + '; '.join(self.degraded) + ')'
+        return line
+
+
+def _syscall(nr: int, *args: object) -> int:
+    ctypes.set_errno(0)
+    return int(_libc.syscall(ctypes.c_long(nr), *args))
+
+
+def landlock_abi() -> int:
+    """The kernel's Landlock ABI, or 0 when Landlock is unavailable.
+
+    A negative return means the syscall exists but the LSM is not enabled (ENOSYS
+    when the kernel lacks it, EOPNOTSUPP when it was left out of the boot-time lsm=
+    list), and both mean the same thing to us. Off Linux the number would name a
+    different syscall entirely, so it is never dialled.
+    """
+    if sys.platform != 'linux':
+        return 0
+    rc = _syscall(
+        _NR_LANDLOCK_CREATE_RULESET,
+        None,
+        ctypes.c_size_t(0),
+        ctypes.c_uint32(_LANDLOCK_CREATE_RULESET_VERSION),
+    )
+    return rc if rc > 0 else 0
+
+
+def fs_mask(abi: int) -> int:
+    """Every FS right the given ABI understands."""
+    last = _ABI_FS_LAST.get(abi, _ABI_FS_LAST_KNOWN)
+    return (1 << (last + 1)) - 1
+
+
+def _ruleset_attr(abi: int) -> tuple[_RulesetAttr, int]:
+    attr = _RulesetAttr(fs_mask(abi), 0, 0)
+    size = _ATTR_SIZE_FS
+    if abi >= 4:
+        # No net rules are ever added, and a handled access with no rule allowing
+        # it is a denial: this is how "no network" is spelled.
+        attr.handled_access_net = _NET_BIND_TCP | _NET_CONNECT_TCP
+        size = _ATTR_SIZE_NET
+    if abi >= 6:
+        attr.scoped = _SCOPE_ABSTRACT_UNIX_SOCKET | _SCOPE_SIGNAL
+        size = _ATTR_SIZE_SCOPED
+    return attr, size
+
+
+def _rights_for(path: str, access: int) -> int:
+    """The subset of `access` that Landlock will accept for this kind of file."""
+    if not os.path.isdir(path):
+        access &= _FILE_RIGHTS
+    return access
+
+
+def build_policy(
+    kernel: str,
+    rules_dir: str,
+    spatch: str,
+    metadata: str | None = None,
+) -> SandboxPolicy:
+    """The least a scan can run with, derived from resolved paths only.
+
+    Nothing here is a guess about where things live: the interpreter comes from
+    sys.base_prefix (uv, pyenv and conda all put it outside the venv), spatch's
+    payload from the realpath of the binary (standard.h and standard.iso are its
+    siblings), and the rules from resolve_content(). The report file is deliberately
+    absent -- see install(), which pre-opens it instead of granting its directory.
+    """
+    read = [
+        kernel,
+        rules_dir,
+        '/etc',  # ld.so.cache, gitconfig, cvehound.ini
+        '/proc/self',  # spatch readlinks /proc/self/exe to find its payload
+        '/sys/devices/system/cpu',  # spatch reads cpu/online to size its pool
+    ]
+    if metadata:
+        read.append(metadata)
+
+    # Interpreter, libraries, and everywhere cvehound itself might be imported
+    # from. All of it is needed twice over: once for the console-script shebang,
+    # and again under forkserver/spawn (the Linux default from 3.14), where every
+    # worker re-execs python and re-imports cvehound and sympy. A gap here is not a
+    # missed detection but a PermissionError that takes the whole pool down.
+    read_exec = [
+        '/usr',
+        '/bin',
+        '/sbin',
+        '/lib',
+        '/lib64',
+        os.path.dirname(os.path.realpath(spatch)),  # standard.h/.iso are its siblings
+        os.path.realpath(sys.base_prefix),
+        os.path.realpath(sys.prefix),
+        # The package's own parent, which an editable install or `python -m
+        # cvehound` from a checkout puts outside every prefix above.
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        site.getusersitepackages(),
+        *site.getsitepackages(),
+        *_import_roots(),
+    ]
+
+    # /tmp is not negotiable: coccinelle hardcodes /tmp/cocci_small_output-*,
+    # /tmp/.parmap.* and /tmp/nothing, and ignores TMPDIR for them. /dev/shm is the
+    # ProcessPoolExecutor's -- multiprocessing.SemLock is a POSIX named semaphore.
+    write = [
+        tempfile.gettempdir(),
+        '/tmp',
+        '/dev/shm',
+        '/dev/null',
+        '/dev/zero',
+        '/dev/urandom',
+        '/dev/random',
+    ]
+
+    return SandboxPolicy(
+        read=_clean(read),
+        read_exec=_clean(read_exec),
+        write=_clean(write),
+    )
+
+
+def _import_roots() -> list[str]:
+    """sys.path, minus the two entries that would give the whole sandbox away.
+
+    `python -m cvehound` puts the working directory on sys.path as '.', so sweeping
+    it up wholesale grants read and execute over whatever directory the tool was run
+    from -- routinely $HOME, which is most of what the sandbox exists to keep out.
+    The package's own parent is granted separately and unconditionally, so dropping
+    these two costs an import nothing.
+    """
+    excluded = {os.path.abspath(os.getcwd()), os.path.abspath(os.path.expanduser('~'))}
+    roots = []
+    for entry in sys.path:
+        if not entry:
+            continue
+        resolved = os.path.abspath(entry)
+        if resolved not in excluded and os.path.isdir(resolved):
+            roots.append(resolved)
+    return roots
+
+
+def _clean(paths: list[str]) -> tuple[str, ...]:
+    """Absolute, deduplicated, and filtered to what exists -- order preserved."""
+    return tuple(dict.fromkeys(os.path.abspath(p) for p in paths if p and os.path.exists(p)))
+
+
+def build_seccomp_program(arch: str) -> list[tuple[int, int, int, int]]:
+    """Assemble the classic-BPF filter as (code, jt, jf, k) tuples.
+
+    Kept free of ctypes so the assembly can be asserted on directly. Every jump is
+    forward, because classic BPF has no backward branches; the three terminals and
+    the socket() check therefore sit at the end, and the label arithmetic below is
+    what keeps the offsets in the 8-bit jt/jf fields.
+    """
+    deny = sorted(_DENY[arch].values())
+    n = len(deny)
+    # Label layout after the n deny comparisons: allow at 5+n is reached by
+    # falling off the end of them, so only the three jumped-to labels are named.
+    l_deny, l_kill, l_sock = 6 + n, 7 + n, 8 + n
+    prog: list[tuple[int, int, int, int]] = []
+
+    def jump(label: int) -> int:
+        """Offset from the instruction about to be appended to `label`."""
+        return label - len(prog) - 1
+
+    # The architecture check has to come first and has to be fatal. Without it a
+    # process could re-enter through the compat ABI, where the same numbers mean
+    # different syscalls and the deny-list below would wave them through.
+    prog.append((_BPF_LD_W_ABS, 0, 0, _OFF_ARCH))
+    prog.append((_BPF_JMP_JEQ_K, 0, jump(l_kill), _AUDIT_ARCH[arch]))
+    prog.append((_BPF_LD_W_ABS, 0, 0, _OFF_NR))
+    prog.append((_BPF_JMP_JGE_K, jump(l_kill), 0, _X32_SYSCALL_BIT))
+    prog.append((_BPF_JMP_JEQ_K, jump(l_sock), 0, _NR_SOCKET[arch]))
+    for nr in deny:
+        prog.append((_BPF_JMP_JEQ_K, jump(l_deny), 0, nr))
+    prog.append((_BPF_RET_K, 0, 0, _SECCOMP_RET_ALLOW))
+    prog.append((_BPF_RET_K, 0, 0, _SECCOMP_RET_ERRNO | _EPERM))
+    prog.append((_BPF_RET_K, 0, 0, _SECCOMP_RET_KILL_PROCESS))
+    # socket(): the family is a scalar argument, so it can be filtered without
+    # dereferencing anything. AF_UNIX stays because the worker pool needs it.
+    prog.append((_BPF_LD_W_ABS, 0, 0, _OFF_ARG0))
+    prog.append((_BPF_JMP_JEQ_K, 0, 1, _AF_UNIX))
+    prog.append((_BPF_RET_K, 0, 0, _SECCOMP_RET_ALLOW))
+    prog.append((_BPF_RET_K, 0, 0, _SECCOMP_RET_ERRNO | _EAFNOSUPPORT))
+    return prog
+
+
+def _set_no_new_privs() -> None:
+    if _libc.prctl(_PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0:
+        raise OSError(ctypes.get_errno(), 'prctl(PR_SET_NO_NEW_PRIVS) failed')
+
+
+def _install_landlock(policy: SandboxPolicy, abi: int) -> None:
+    attr, size = _ruleset_attr(abi)
+    mask = fs_mask(abi)
+    fd = _syscall(
+        _NR_LANDLOCK_CREATE_RULESET,
+        ctypes.byref(attr),
+        ctypes.c_size_t(size),
+        ctypes.c_uint32(0),
+    )
+    if fd < 0:
+        raise OSError(ctypes.get_errno(), 'landlock_create_ruleset failed')
+    try:
+        ro = FS['READ_FILE'] | FS['READ_DIR']
+        for paths, access in (
+            (policy.read, ro),
+            (policy.read_exec, ro | FS['EXECUTE']),
+            (policy.write, mask),
+        ):
+            for path in paths:
+                _add_path(fd, path, _rights_for(path, access & mask))
+        _set_no_new_privs()
+        if _syscall(_NR_LANDLOCK_RESTRICT_SELF, ctypes.c_int(fd), ctypes.c_uint32(0)) != 0:
+            raise OSError(ctypes.get_errno(), 'landlock_restrict_self failed')
+    finally:
+        os.close(fd)
+
+
+def _add_path(ruleset_fd: int, path: str, access: int) -> None:
+    if not access:
+        return
+    try:
+        path_fd = os.open(path, os.O_PATH | os.O_CLOEXEC)
+    except OSError:
+        # A path that vanished between build_policy() and here is not worth
+        # failing over; self_test() covers the ones we actually depend on.
+        return
+    try:
+        attr = _PathBeneathAttr(access, path_fd)
+        rc = _syscall(
+            _NR_LANDLOCK_ADD_RULE,
+            ctypes.c_int(ruleset_fd),
+            ctypes.c_int(_LANDLOCK_RULE_PATH_BENEATH),
+            ctypes.byref(attr),
+            ctypes.c_uint32(0),
+        )
+        if rc != 0:
+            raise OSError(ctypes.get_errno(), f'landlock_add_rule failed for {path}')
+    finally:
+        os.close(path_fd)
+
+
+def _install_seccomp() -> bool:
+    # platform.machine() reports the *kernel*, so a 32-bit interpreter on an
+    # x86_64 kernel also says 'x86_64'. Installing the 64-bit filter there would
+    # fail its own AUDIT_ARCH check on every syscall and SIGSYS the tool dead.
+    arch = platform.machine()
+    if sys.platform != 'linux' or arch not in _DENY or sys.maxsize <= 2**32:
+        return False
+    prog = build_seccomp_program(arch)
+    filters = (_SockFilter * len(prog))(*[_SockFilter(*insn) for insn in prog])
+    fprog = _SockFprog(len(prog), filters)
+    _set_no_new_privs()
+    rc = _syscall(
+        _NR_SECCOMP[arch],
+        ctypes.c_ulong(_SECCOMP_SET_MODE_FILTER),
+        ctypes.c_ulong(_SECCOMP_FILTER_FLAG_TSYNC),
+        ctypes.byref(fprog),
+    )
+    if rc != 0:
+        raise OSError(ctypes.get_errno(), 'seccomp(SECCOMP_SET_MODE_FILTER) failed')
+    return True
+
+
+def apply(policy: SandboxPolicy) -> SandboxStatus:
+    """Install what this kernel supports; report what it could not.
+
+    Degrading is this function's job because nothing here is irreversible until
+    landlock_restrict_self, and by then there is no way back. The two mechanisms
+    degrade independently: a kernel without Landlock still gets the syscall filter.
+    """
+    degraded: list[str] = []
+
+    abi = landlock_abi()
+    if abi < 1:
+        abi = 0
+        degraded.append('landlock unavailable on this kernel')
+    else:
+        try:
+            _install_landlock(policy, abi)
+        except OSError as err:
+            abi = 0
+            degraded.append(f'landlock not installed: {err}')
+
+    seccomp = False
+    try:
+        seccomp = _install_seccomp()
+        if not seccomp:
+            degraded.append(f'no seccomp syscall table for {platform.machine()}')
+    except OSError as err:
+        degraded.append(f'seccomp not installed: {err}')
+
+    return SandboxStatus(landlock_abi=abi, seccomp=seccomp, degraded=tuple(degraded))
+
+
+def self_test(policy: SandboxPolicy, kernel: str, rules_dir: str, spatch: str) -> None:
+    """Prove the allowed set still works, now that it cannot be widened.
+
+    This exists because the failure it catches is invisible: handed a tree it
+    cannot read, spatch prints "0 files match" and exits 0, so a policy that is one
+    path too tight reports a clean kernel instead of an error.
+
+    It reads the policy rather than a list of its own, so that a path added to
+    build_policy() is covered the moment it is granted. A hand-written list would
+    drift, and the whole point of this function is catching drift.
+    """
+    failures: list[str] = []
+
+    for path in policy.read + policy.read_exec:
+        failures.extend(_unreadable(path))
+    for path in policy.write:
+        failures.extend(_unwritable(path))
+
+    # The loops above prove what the policy granted. The other way to be one path
+    # too tight is for build_policy() to have dropped one -- it does that silently
+    # for anything that does not exist -- which reads the same at scan time: no
+    # grant, nothing readable, "0 files match".
+    granted = {*policy.read, *policy.read_exec, *policy.write}
+    for label, path in (('kernel tree', kernel), ('rules', rules_dir)):
+        if os.path.abspath(path) not in granted:
+            failures.append(f'the {label} at {path} was never granted')
+    if not os.access(spatch, os.X_OK):
+        failures.append(f'cannot execute spatch at {spatch}')
+    failures.extend(check_git_prefilter(kernel))
+
+    if failures:
+        raise SandboxError(failures)
+
+
+def _unreadable(path: str) -> list[str]:
+    """Whether the granted path can still be opened for what it is."""
+    try:
+        if os.path.isdir(path):
+            with os.scandir(path) as entries:
+                next(iter(entries), None)
+        else:
+            with open(path, 'rb'):
+                pass
+    except OSError as err:
+        return [f'cannot read {path}: {err}']
+    return []
+
+
+def _unwritable(path: str) -> list[str]:
+    """Whether the granted path can still be written.
+
+    Only directories are probed. The character devices in the write set (/dev/null
+    and friends) are granted for spatch and the pool to open, and writing to them
+    here would prove nothing a mode bit does not already guarantee.
+    """
+    if not os.path.isdir(path):
+        return []
+    try:
+        fd, name = tempfile.mkstemp(prefix='cvehound-sandbox-', dir=path)
+        os.write(fd, b'x')
+        os.close(fd)
+        os.unlink(name)
+    except OSError as err:
+        return [f'cannot write in {path}: {err}']
+    return []
+
+
+def install(
+    kernel: str,
+    rules_dir: str,
+    spatch: str,
+    metadata: str | None = None,
+    strict: bool = False,
+) -> SandboxStatus:
+    """Build, apply and verify. The only entry point the CLI needs.
+
+    strict turns every degradation into a refusal to scan, for callers who would
+    rather not run at all than run unconfined.
+    """
+    policy = build_policy(kernel, rules_dir, spatch, metadata)
+    status = apply(policy)
+    if status.degraded and strict:
+        raise SandboxError(list(status.degraded))
+    if status.landlock_abi:
+        self_test(policy, kernel, rules_dir, spatch)
+    logging.info(status.summary())
+    return status

--- a/tests/test_15_sandbox.py
+++ b/tests/test_15_sandbox.py
@@ -1,0 +1,632 @@
+#!/usr/bin/env python3
+
+"""Pin the sandbox to the two things that can go wrong with it.
+
+It can fail to confine -- a rights mask that quietly drops the bit it meant to
+set, a filter whose jump lands past its own program -- and it can confine too
+much, which is the worse half: denied a path it needs, spatch prints "0 files
+match" and exits 0, so an over-tight policy reads as a clean kernel rather than
+an error. The unit tests below cover the assembly, and the live ones prove both
+directions on the running kernel: things that must be denied are, and a rule
+that fires unsandboxed still fires sandboxed.
+
+Everything that installs a sandbox runs in a child process. landlock_restrict_self
+cannot be undone, so a test that applied one in-process would confine the rest of
+the session -- pytest's own writes included.
+"""
+
+import ctypes
+import json
+import os
+import pickle
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+
+import pytest
+from conftest import write_tree
+
+import cvehound.sandbox as sandbox
+from cvehound.exception import SandboxError
+from cvehound.sandbox import (
+    _DENY,
+    _NR_SOCKET,
+    FS,
+    SandboxPolicy,
+    _PathBeneathAttr,
+    _rights_for,
+    _ruleset_attr,
+    build_policy,
+    build_seccomp_program,
+    fs_mask,
+    landlock_abi,
+    self_test,
+)
+
+ARCHES = tuple(sandbox._DENY)
+
+
+# --- units: the bits and the program --------------------------------------
+
+
+@pytest.mark.parametrize(
+    ('abi', 'highest'),
+    [(1, 'MAKE_SYM'), (2, 'REFER'), (3, 'TRUNCATE'), (4, 'TRUNCATE'), (5, 'IOCTL_DEV')],
+    ids=lambda v: str(v),
+)
+def test_fs_mask_stops_at_the_abi(abi, highest):
+    """Each ABI gets every right up to its own, and none above it."""
+    mask = fs_mask(abi)
+    assert mask & FS[highest]
+    above = {name: bit for name, bit in FS.items() if bit > FS[highest]}
+    assert not [name for name, bit in above.items() if mask & bit]
+
+
+def test_fs_mask_does_not_guess_past_the_table():
+    """A kernel newer than the table gets what we understand, not what we hope.
+
+    Landlock fails the whole ruleset for one unknown bit, so an ABI we have never
+    seen has to be treated as the newest we have, never as "probably has more".
+    """
+    assert fs_mask(99) == fs_mask(5)
+
+
+@pytest.mark.parametrize(('abi', 'size'), [(1, 8), (3, 8), (4, 16), (5, 16), (6, 24), (9, 24)])
+def test_ruleset_attr_is_sized_for_the_abi(abi, size):
+    attr, got = _ruleset_attr(abi)
+    assert got == size
+    # Net and scope fields must stay zero when they are not being sent, or the
+    # kernel reads a non-zero tail it does not know about.
+    assert (attr.handled_access_net == 0) == (size < 16)
+    assert (attr.scoped == 0) == (size < 24)
+
+
+def test_path_beneath_attr_is_packed():
+    """landlock_add_rule takes no size, so 12 bytes is the only layout it reads."""
+    assert ctypes.sizeof(_PathBeneathAttr) == 12
+
+
+def test_directory_only_rights_are_dropped_for_a_file(tmp_path):
+    """Landlock answers EINVAL for MAKE_DIR on /dev/null rather than ignoring it."""
+    a_file = tmp_path / 'f'
+    a_file.write_text('')
+    mask = fs_mask(5)
+
+    on_dir = _rights_for(str(tmp_path), mask)
+    on_file = _rights_for(str(a_file), mask)
+
+    assert on_dir & FS['MAKE_DIR']
+    assert not on_file & FS['MAKE_DIR']
+    assert on_file & FS['WRITE_FILE']
+    assert on_file & FS['READ_FILE']
+
+
+def test_rights_are_clamped_by_the_abi_mask():
+    """An old ABI must not be handed a right that only a newer one defines.
+
+    Landlock fails the whole ruleset for one unknown bit, so the clamp the
+    installer applies before asking for a path is what keeps ABI 1 usable.
+    """
+    assert not _rights_for('/', fs_mask(5) & fs_mask(1)) & FS['IOCTL_DEV']
+
+
+@pytest.mark.parametrize('arch', ARCHES)
+def test_seccomp_jumps_are_forward_and_addressable(arch):
+    """Classic BPF has no backward branch and one byte per offset.
+
+    Both limits are silent when broken: an offset that overflows a byte wraps, and
+    the filter then allows whatever it lands on.
+    """
+    prog = build_seccomp_program(arch)
+    jumps = 0
+    for i, (code, jt, jf, _k) in enumerate(prog):
+        if code & 0x07 != 0x05:  # BPF_JMP; jt/jf are unread on every other class
+            continue
+        jumps += 1
+        assert 0 <= jt <= 255 and 0 <= jf <= 255
+        assert i + 1 + jt < len(prog)
+        assert i + 1 + jf < len(prog)
+    assert jumps > len(prog) // 2, 'the deny comparisons went missing'
+
+
+@pytest.mark.parametrize('arch', ARCHES)
+def test_seccomp_checks_the_architecture_before_anything_else(arch):
+    """Without this first, the compat ABI renumbers every syscall past the filter."""
+    prog = build_seccomp_program(arch)
+    load_arch, check_arch = prog[0], prog[1]
+    assert load_arch[3] == 4  # offsetof(struct seccomp_data, arch)
+    # The mismatch branch has to be the fatal one, not an errno.
+    kill = prog[1 + 1 + check_arch[2]]
+    assert kill[3] == 0x80000000  # SECCOMP_RET_KILL_PROCESS
+
+
+@pytest.mark.parametrize('arch', ARCHES)
+def test_seccomp_denies_the_families_landlock_cannot(arch):
+    """The point of the filter: what Landlock has no way to express."""
+    compared = {k for _code, _jt, _jf, k in build_seccomp_program(arch)}
+    for name in ('ptrace', 'bpf', 'io_uring_setup', 'unshare', 'userfaultfd', 'keyctl'):
+        assert _DENY[arch][name] in compared, name
+    # socket() is filtered on its family rather than denied: the worker pool needs
+    # AF_UNIX, and nothing in a scan needs any other family.
+    assert _NR_SOCKET[arch] in compared
+    assert 1 in compared  # AF_UNIX
+
+
+def test_sandbox_error_survives_a_pickle_round_trip():
+    """Exceptions in this package cross the pool boundary; this one may follow."""
+    err = pickle.loads(pickle.dumps(SandboxError(['no landlock', 'no seccomp'])))
+    assert err.reasons == ['no landlock', 'no seccomp']
+    assert 'no landlock' in str(err)
+
+
+def test_build_policy_drops_paths_that_do_not_exist(tmp_path):
+    policy = build_policy(
+        str(tmp_path), str(tmp_path), sys.executable, metadata=str(tmp_path / 'absent.gz')
+    )
+    assert str(tmp_path) in policy.read
+    granted = policy.read + policy.read_exec + policy.write
+    assert not [p for p in granted if not os.path.exists(p)]
+
+
+def test_build_policy_covers_what_a_scan_reaches_for():
+    """The paths whose absence would abort a real scan, each for a traced reason."""
+    policy = build_policy('/etc', '/etc', sys.executable)
+    # The interpreter, wherever it lives -- uv, pyenv and conda all put it outside
+    # the venv, and the worker pool re-execs it under forkserver.
+    assert os.path.realpath(sys.base_prefix) in policy.read_exec
+    # coccinelle hardcodes /tmp/cocci_small_output-*; multiprocessing.SemLock is a
+    # POSIX named semaphore under /dev/shm.
+    assert '/tmp' in policy.write
+    assert '/dev/shm' in policy.write
+    assert '/dev/null' in policy.write
+
+
+def test_self_test_reports_a_path_it_cannot_reach(tmp_path):
+    """The guard against the silent half: an unreadable tree must raise, not scan."""
+    missing = str(tmp_path / 'nope')
+    with pytest.raises(SandboxError) as excinfo:
+        self_test(SandboxPolicy(), missing, str(tmp_path), sys.executable)
+    assert missing in str(excinfo.value)
+
+
+def test_self_test_passes_when_the_policy_grants_what_it_covers(tmp_path):
+    (tmp_path / 'a').write_text('')
+    policy = SandboxPolicy(read=(str(tmp_path),), write=(str(tmp_path),))
+    self_test(policy, str(tmp_path), str(tmp_path), sys.executable)
+
+
+def test_self_test_catches_a_tree_the_policy_never_granted(tmp_path):
+    """The other way to be one path too tight, and it reads identically.
+
+    build_policy() drops a path that does not exist rather than failing, so a
+    mistyped --kernel yields a policy granting nothing there -- and a tree the
+    scan cannot read is a tree the scan calls clean.
+    """
+    gone = str(tmp_path / 'gone')
+    policy = build_policy(gone, str(tmp_path), sys.executable)
+    assert gone not in policy.read
+    with pytest.raises(SandboxError, match='never granted'):
+        self_test(policy, gone, str(tmp_path), sys.executable)
+
+
+# --- live: what the running kernel actually enforces -----------------------
+
+landlock = pytest.mark.skipif(landlock_abi() < 1, reason='kernel has no Landlock')
+
+
+def _child(code, *argv):
+    """Run a probe in its own interpreter and hand back what it printed.
+
+    A sandbox cannot be taken back off, so every one of these has to be its own
+    process; each child reports through a single JSON object on stdout.
+    """
+    run = subprocess.run(
+        [sys.executable, '-c', textwrap.dedent(code), *argv],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+    assert run.returncode == 0, run.stderr
+    return json.loads(run.stdout)
+
+
+# EACCES/EPERM/EAFNOSUPPORT are the sandbox saying no. Anything else -- most of
+# all ECONNREFUSED from a port nobody listens on -- is the probe answering its own
+# question, so the assertions below check the errno rather than "it raised".
+DENIALS = (13, 1, 97)
+
+PROBES = """
+    import json, os, socket, sys
+    from cvehound.sandbox import SandboxPolicy, apply
+
+    status = apply(SandboxPolicy(
+        read=('/etc',), read_exec=('/usr', '/lib', '/lib64'), write=('/tmp',),
+    ))
+    out = {'abi': status.landlock_abi, 'seccomp': status.seccomp, 'errno': {}}
+
+    def probe(name, fn):
+        try:
+            got = fn()
+        except OSError as err:
+            out['errno'][name] = err.errno
+            return
+        out['errno'][name] = 0
+        if hasattr(got, 'close'):
+            got.close()
+
+    home = os.path.expanduser('~/.cvehound-sandbox-probe')
+    probe('home_write', lambda: open(home, 'w'))
+    if not out['errno']['home_write']:
+        os.unlink(home)
+    # The home directory, not /etc/shadow: the real policy grants /etc read, so a
+    # denial there would be file mode 0600 answering, not Landlock.
+    probe('home_read', lambda: os.listdir(os.path.expanduser('~')))
+    probe('tcp_connect', lambda: socket.create_connection(('127.0.0.1', 9), 1))
+    probe('udp_socket', lambda: socket.socket(socket.AF_INET, socket.SOCK_DGRAM))
+    probe('netlink_socket', lambda: socket.socket(socket.AF_NETLINK, socket.SOCK_RAW, 0))
+    probe('unix_socket', lambda: socket.socket(socket.AF_UNIX, socket.SOCK_STREAM))
+    probe('tmp_write', lambda: open('/tmp/.cvehound-sandbox-probe', 'w'))
+    if not out['errno']['tmp_write']:
+        os.unlink('/tmp/.cvehound-sandbox-probe')
+    print(json.dumps(out))
+"""
+
+
+@landlock
+def test_the_sandbox_denies_what_it_advertises():
+    out = _child(PROBES)
+    errno = out['errno']
+
+    assert out['abi'] >= 1
+    assert errno['home_write'] in DENIALS, 'the home directory is still writable'
+    assert errno['home_read'] in DENIALS, 'the home directory is still readable'
+    if out['abi'] >= 4 or out['seccomp']:
+        assert errno['tcp_connect'] in DENIALS, f'TCP is still reachable ({errno["tcp_connect"]})'
+    if out['seccomp']:
+        # Landlock governs TCP only, which is exactly why the filter is there.
+        assert errno['udp_socket'] in DENIALS, 'UDP is still reachable'
+        assert errno['netlink_socket'] in DENIALS, 'netlink is still reachable'
+
+    # The other half: the pool needs AF_UNIX, and spatch needs to write /tmp.
+    assert not errno['unix_socket'], 'AF_UNIX was denied; the worker pool needs it'
+    assert not errno['tmp_write'], '/tmp was denied; coccinelle hardcodes paths there'
+
+
+@landlock
+def test_install_self_tests_the_policy_it_just_locked(hound):
+    """install() must come back clean on the tree a scan is about to read."""
+    out = _child(INSTALL, hound.kernel, hound.spatch)
+    assert out['abi'] >= 1
+    assert not out['degraded'], out['degraded']
+
+
+# The one rule this file names. The equivalence check needs a rule that actually
+# fires, and firing needs source the rule matches -- so the tree below is built
+# from this rule's own starred lines. If the rule ever goes away the test skips
+# rather than passing on a tree nothing looks at.
+FIRES_CVE = 'CVE-2013-2930'
+VULNERABLE = (
+    'static int perf_trace_event_perm(struct ftrace_event_call *tp_event,\n'
+    '\t\t\t\t struct perf_event *p_event)\n'
+    '{\n'
+    '\tif (ftrace_event_is_function(tp_event) &&\n'
+    '\t    perf_paranoid_kernel() &&\n'
+    '\t    !capable(CAP_SYS_ADMIN))\n'
+    '\t\treturn -EPERM;\n'
+    '\n'
+    '\treturn 0;\n'
+    '}\n'
+)
+
+
+@pytest.fixture(scope='module')
+def vulnerable_tree(tmp_path_factory):
+    """A tree small enough to scan twice, real enough for the CLI to accept."""
+    root = tmp_path_factory.mktemp('vulnerable-tree')
+    write_tree(
+        root,
+        {
+            'Makefile': 'VERSION = 5\nPATCHLEVEL = 10\nSUBLEVEL = 0\nEXTRAVERSION =\n',
+            'kernel/trace/trace_event_perf.c': VULNERABLE,
+        },
+    )
+    return root
+
+
+@pytest.mark.slow
+@landlock
+def test_a_rule_that_fires_unsandboxed_still_fires_sandboxed(hound, vulnerable_tree, tmp_path):
+    """The regression this whole module is scaffolding for.
+
+    A policy one path too tight costs detections without costing an exit code, so
+    comparing verdicts across the two modes is the only check that would notice.
+    """
+    if FIRES_CVE not in hound.cve_all_rules:
+        pytest.skip(f'{FIRES_CVE} is no longer a rule in this tree')
+
+    verdicts = {}
+    for mode in ('off', 'strict'):
+        report = tmp_path / f'{mode}.json'
+        run = subprocess.run(
+            [
+                sys.executable,
+                '-m',
+                'cvehound',
+                '--kernel',
+                str(vulnerable_tree),
+                '--cve',
+                FIRES_CVE,
+                '--report',
+                str(report),
+                f'--sandbox={mode}',
+            ],
+            capture_output=True,
+            text=True,
+            timeout=600,
+            check=False,
+        )
+        assert run.returncode == 0, f'--sandbox={mode} failed: {run.stderr}'
+        loaded = json.loads(report.read_text())
+        verdicts[mode] = (sorted(loaded['results']), loaded['errors'])
+
+    assert verdicts['off'][0] == [FIRES_CVE], 'the fixture stopped being vulnerable'
+    assert verdicts['strict'] == verdicts['off']
+
+
+DEGRADE = """
+    import json, sys
+    import cvehound.sandbox as sandbox
+    from cvehound.exception import SandboxError
+
+    # Stand in for a kernel built without Landlock, or one that left it out of
+    # the boot-time lsm= list. Both report the same way.
+    sandbox.landlock_abi = lambda: 0
+
+    status = sandbox.apply(sandbox.SandboxPolicy(read=('/etc',)))
+    strict = None
+    try:
+        sandbox.install('/etc', '/etc', sys.argv[1], strict=True)
+    except SandboxError as err:
+        strict = str(err)
+    print(json.dumps({
+        'abi': status.landlock_abi,
+        'degraded': list(status.degraded),
+        'summary': status.summary(),
+        'strict': strict,
+    }))
+"""
+
+
+INSTALL = """
+    import json, sys
+    from cvehound.content import resolve_content
+    from cvehound.sandbox import install
+
+    status = install(sys.argv[1], resolve_content().rules_dir, sys.argv[2])
+    print(json.dumps({'abi': status.landlock_abi, 'degraded': list(status.degraded)}))
+"""
+
+
+def test_a_kernel_without_landlock_degrades_but_strict_refuses(hound):
+    """The default is on-with-fallback, so the fallback is load-bearing.
+
+    auto has to come back with a scan still possible and a reason worth printing;
+    strict has to refuse rather than scan unconfined. Neither can be checked in
+    process -- apply() installs a seccomp filter that outlives the assertion.
+    """
+    out = _child(DEGRADE, hound.spatch)
+
+    assert out['abi'] == 0
+    assert any('landlock' in reason for reason in out['degraded'])
+    assert 'landlock' in out['summary']
+    assert out['strict'] is not None, 'strict scanned anyway'
+    assert 'landlock' in out['strict']
+
+
+def test_the_working_directory_is_not_swept_in_from_sys_path(monkeypatch, tmp_path):
+    """`python -m cvehound` puts '.' on sys.path, and $HOME is a common cwd.
+
+    Granting sys.path wholesale would hand read and execute over whatever directory
+    the tool was run from -- which is most of what the sandbox is for. The package's
+    own parent is granted on its own line, so nothing an import needs rides on this.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.syspath_prepend('.')
+    home = os.path.abspath(os.path.expanduser('~'))
+    monkeypatch.syspath_prepend(home)
+
+    policy = build_policy(str(tmp_path), str(tmp_path), sys.executable)
+
+    assert str(tmp_path) not in policy.read_exec, 'the working directory was granted'
+    assert home not in policy.read_exec, '$HOME was granted'
+    # ...while cvehound itself stays importable, which is what a forkserver worker
+    # re-does after the lock.
+    package_parent = os.path.dirname(os.path.dirname(os.path.abspath(sandbox.__file__)))
+    assert package_parent in policy.read_exec
+
+
+# --- the raw numbers, checked against the kernel's own headers -------------
+#
+# Every constant in cvehound/sandbox.py is a value from a uapi header that
+# cannot be imported from Python. Typing them out is unavoidable; leaving them
+# unchecked is not. These tests ask the C preprocessor what the headers on this
+# machine actually say, so a transcription error fails here instead of silently
+# confining the wrong thing -- or, worse, failing open.
+
+PROBE_TEMPLATE = """\
+#include <stdio.h>
+#include <linux/landlock.h>
+#include <linux/seccomp.h>
+#include <linux/audit.h>
+#include <linux/prctl.h>
+#include <linux/bpf_common.h>
+#include <asm/unistd_64.h>
+int main(void) {{
+{body}
+    return 0;
+}}
+"""
+
+
+def _ask_the_headers(wanted):
+    """{{key: C expression}} -> {{key: value}}, as this machine's headers define it.
+
+    Each line is #ifdef-guarded on its own macro, so a header too old to know a
+    constant simply omits it rather than failing the build -- an ABI we cannot
+    check here is not the same as one we got wrong.
+    """
+    if not shutil.which('cc'):
+        pytest.skip('no C compiler to read the kernel headers with')
+    body = '\n'.join(
+        f'#ifdef {guard}\n    printf("{key} %llu\\n", (unsigned long long)({expr}));\n#endif'
+        for key, (expr, guard) in wanted.items()
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        src = os.path.join(tmp, 'probe.c')
+        exe = os.path.join(tmp, 'probe')
+        with open(src, 'w') as fh:
+            fh.write(PROBE_TEMPLATE.format(body=body))
+        built = subprocess.run(['cc', src, '-o', exe], capture_output=True, text=True, check=False)
+        if built.returncode != 0:
+            pytest.skip(f'kernel uapi headers unavailable: {built.stderr.strip()[:200]}')
+        run = subprocess.run([exe], capture_output=True, text=True, check=True)
+    out = {}
+    for line in run.stdout.split('\n'):
+        if line:
+            name, value = line.split()
+            out[name] = int(value)
+    return out
+
+
+def test_landlock_constants_match_the_kernel_headers():
+    wanted = {f'FS_{n}': (f'LANDLOCK_ACCESS_FS_{n}', f'LANDLOCK_ACCESS_FS_{n}') for n in FS}
+    wanted.update(
+        {
+            'NET_BIND': ('LANDLOCK_ACCESS_NET_BIND_TCP', 'LANDLOCK_ACCESS_NET_BIND_TCP'),
+            'NET_CONNECT': ('LANDLOCK_ACCESS_NET_CONNECT_TCP', 'LANDLOCK_ACCESS_NET_CONNECT_TCP'),
+            'SCOPE_UNIX': (
+                'LANDLOCK_SCOPE_ABSTRACT_UNIX_SOCKET',
+                'LANDLOCK_SCOPE_ABSTRACT_UNIX_SOCKET',
+            ),
+            'SCOPE_SIGNAL': ('LANDLOCK_SCOPE_SIGNAL', 'LANDLOCK_SCOPE_SIGNAL'),
+            'VERSION': ('LANDLOCK_CREATE_RULESET_VERSION', 'LANDLOCK_CREATE_RULESET_VERSION'),
+            'PATH_BENEATH': ('LANDLOCK_RULE_PATH_BENEATH', 'LANDLOCK_RULE_PATH_BENEATH'),
+        }
+    )
+    got = _ask_the_headers(wanted)
+
+    for name, bit in FS.items():
+        if f'FS_{name}' in got:
+            assert got[f'FS_{name}'] == bit, f'LANDLOCK_ACCESS_FS_{name}'
+    for key, ours in (
+        ('NET_BIND', sandbox._NET_BIND_TCP),
+        ('NET_CONNECT', sandbox._NET_CONNECT_TCP),
+        ('SCOPE_UNIX', sandbox._SCOPE_ABSTRACT_UNIX_SOCKET),
+        ('SCOPE_SIGNAL', sandbox._SCOPE_SIGNAL),
+        ('VERSION', sandbox._LANDLOCK_CREATE_RULESET_VERSION),
+        ('PATH_BENEATH', sandbox._LANDLOCK_RULE_PATH_BENEATH),
+    ):
+        if key in got:
+            assert got[key] == ours, key
+    # The FS table is a bit-per-right list; a header that knows a right we do not
+    # is fine, but a gap in the middle would silently shift every later bit.
+    assert got['FS_EXECUTE'] == 1
+
+
+def test_seccomp_and_bpf_constants_match_the_kernel_headers():
+    got = _ask_the_headers(
+        {
+            'RET_KILL_PROCESS': ('SECCOMP_RET_KILL_PROCESS', 'SECCOMP_RET_KILL_PROCESS'),
+            'RET_ERRNO': ('SECCOMP_RET_ERRNO', 'SECCOMP_RET_ERRNO'),
+            'RET_ALLOW': ('SECCOMP_RET_ALLOW', 'SECCOMP_RET_ALLOW'),
+            'SET_MODE_FILTER': ('SECCOMP_SET_MODE_FILTER', 'SECCOMP_SET_MODE_FILTER'),
+            'FLAG_TSYNC': ('SECCOMP_FILTER_FLAG_TSYNC', 'SECCOMP_FILTER_FLAG_TSYNC'),
+            'NNP': ('PR_SET_NO_NEW_PRIVS', 'PR_SET_NO_NEW_PRIVS'),
+            'LD_W_ABS': ('BPF_LD|BPF_W|BPF_ABS', 'BPF_LD'),
+            'JMP_JEQ_K': ('BPF_JMP|BPF_JEQ|BPF_K', 'BPF_JMP'),
+            'JMP_JGE_K': ('BPF_JMP|BPF_JGE|BPF_K', 'BPF_JMP'),
+            'RET_K': ('BPF_RET|BPF_K', 'BPF_RET'),
+            'ARCH_NATIVE': (f'AUDIT_ARCH_{platform.machine().upper()}', 'AUDIT_ARCH_X86_64'),
+        }
+    )
+    for key, ours in (
+        ('RET_KILL_PROCESS', sandbox._SECCOMP_RET_KILL_PROCESS),
+        ('RET_ERRNO', sandbox._SECCOMP_RET_ERRNO),
+        ('RET_ALLOW', sandbox._SECCOMP_RET_ALLOW),
+        ('SET_MODE_FILTER', sandbox._SECCOMP_SET_MODE_FILTER),
+        ('FLAG_TSYNC', sandbox._SECCOMP_FILTER_FLAG_TSYNC),
+        ('NNP', sandbox._PR_SET_NO_NEW_PRIVS),
+        ('LD_W_ABS', sandbox._BPF_LD_W_ABS),
+        ('JMP_JEQ_K', sandbox._BPF_JMP_JEQ_K),
+        ('JMP_JGE_K', sandbox._BPF_JMP_JGE_K),
+        ('RET_K', sandbox._BPF_RET_K),
+    ):
+        if key in got:
+            assert got[key] == ours, key
+    if 'ARCH_NATIVE' in got and platform.machine() in sandbox._AUDIT_ARCH:
+        assert got['ARCH_NATIVE'] == sandbox._AUDIT_ARCH[platform.machine()]
+
+
+def test_native_syscall_numbers_match_the_kernel_headers():
+    """The deny-list is only a deny-list if the numbers name the right calls."""
+    arch = platform.machine()
+    if arch not in sandbox._DENY:
+        pytest.skip(f'no syscall table for {arch}')
+    wanted = {n: (f'__NR_{n}', f'__NR_{n}') for n in sandbox._DENY[arch]}
+    wanted['socket'] = ('__NR_socket', '__NR_socket')
+    wanted['seccomp'] = ('__NR_seccomp', '__NR_seccomp')
+    wanted['landlock_create_ruleset'] = (
+        '__NR_landlock_create_ruleset',
+        '__NR_landlock_create_ruleset',
+    )
+    wanted['landlock_add_rule'] = ('__NR_landlock_add_rule', '__NR_landlock_add_rule')
+    wanted['landlock_restrict_self'] = (
+        '__NR_landlock_restrict_self',
+        '__NR_landlock_restrict_self',
+    )
+    got = _ask_the_headers(wanted)
+
+    for name, number in sandbox._DENY[arch].items():
+        if name in got:
+            assert got[name] == number, f'__NR_{name} on {arch}'
+    for key, ours in (
+        ('socket', sandbox._NR_SOCKET[arch]),
+        ('seccomp', sandbox._NR_SECCOMP[arch]),
+        ('landlock_create_ruleset', sandbox._NR_LANDLOCK_CREATE_RULESET),
+        ('landlock_add_rule', sandbox._NR_LANDLOCK_ADD_RULE),
+        ('landlock_restrict_self', sandbox._NR_LANDLOCK_RESTRICT_SELF),
+    ):
+        if key in got:
+            assert got[key] == ours, key
+    assert len([n for n in sandbox._DENY[arch] if n in got]) > 15, 'headers checked almost nothing'
+
+
+def test_aarch64_syscall_numbers_match_asm_generic():
+    """aarch64 takes the asm-generic table verbatim, and it is plain #defines.
+
+    Worth checking from an x86_64 box too: nothing else in the suite can catch a
+    typo in the table for the architecture the developer is not sitting on.
+    """
+    header = '/usr/include/asm-generic/unistd.h'
+    if not os.path.isfile(header):
+        pytest.skip('asm-generic/unistd.h not installed')
+    with open(header) as fh:
+        text = fh.read()
+    numbers = dict(re.findall(r'^#define __NR_(\w+)\s+(\d+)$', text, re.MULTILINE))
+    if not numbers:
+        pytest.skip('asm-generic/unistd.h has no plain __NR_ defines')
+
+    checked = 0
+    for name, number in {
+        **sandbox._DENY['aarch64'],
+        'socket': sandbox._NR_SOCKET['aarch64'],
+    }.items():
+        if name in numbers:
+            assert int(numbers[name]) == number, f'__NR_{name} on aarch64'
+            checked += 1
+    assert checked > 15, 'the generic header checked almost nothing'


### PR DESCRIPTION
A scan hands an untrusted source tree to spatch, driven by .cocci rules that `cvehound update` fetches over the network -- and spatch is not a leaf process. Traced under our own argv it shells out to /bin/sh, git, find, rm and diff. All of that ran with the user's full ambient authority: nothing stopped a rule or a parser bug from reading ~/.ssh, rewriting a dotfile, or opening a socket.

The timeouts already bound how long a rule may run. This bounds what it may touch. Landlock takes the filesystem and TCP; a seccomp deny-list closes what Landlock structurally cannot express -- UDP, netlink, raw sockets, io_uring, ptrace, namespace syscalls. Both are pure ctypes, so no new dependency, and both are inherited across fork *and* execve: the single call in __main__.py, placed where no thread or child exists yet, covers the worker pool, every spatch, and everything spatch runs in turn.

--sandbox=auto is the default and falls back to an unconfined scan on a kernel without Landlock; strict refuses to scan instead; off skips it.

What makes this delicate is that the failure is silent. Denied a path it needs, spatch prints "0 files match" and exits 0 -- a missed CVE indistinguishable from a clean tree. So apply() degrades while degrading is still possible, and self_test() runs after landlock_restrict_self, where it can only abort. It proves the allowed set positively and drives off the policy, so a path added to build_policy() is covered the moment it is granted rather than whenever someone remembers to extend a second list.

Three grants look wrong and are not: /tmp (coccinelle hardcodes /tmp/cocci_small_output-* and ignores TMPDIR for it), /dev/shm (multiprocessing.SemLock is a POSIX named semaphore, and the pool dies without it), and sys.base_prefix (uv, pyenv and conda all put the interpreter outside the venv, which a forkserver worker re-execs). The report file gets no grant at all -- it is pre-opened, because granting its directory would mean write access to the CWD, routinely $HOME.

spatch now also runs with GIT_CONFIG_GLOBAL=/dev/null and GIT_CONFIG_NOSYSTEM=1: handed a directory it prefilters with `git grep`, and that git was reading the user's ~/.gitconfig, so a setting there could change what a scan found on one machine and not another. safe.directory is supplied over GIT_CONFIG_*, the "command" scope git has treated as protected since 2.38, so a checkout owned by another user still scans -- and naming one realpath is not the blanket bypass safe.directory=* would be.

The uapi constants have no Python equivalent and had to be written out. The tests check every one of them -- both syscall tables, the Landlock bits, the BPF opcodes -- against this machine's own kernel headers through the C preprocessor, so a transcription error fails the suite instead of quietly confining the wrong thing.